### PR TITLE
Fixed missing cookies, when querying graphql on a server component

### DIFF
--- a/studyAi/prisma/schema.prisma
+++ b/studyAi/prisma/schema.prisma
@@ -63,6 +63,7 @@ model Question {
   questionInfo QuestionInfoData
   answer       AnswerData
   likeCounter  LikeCounter
+  private Boolean
 
   @@index([creatorId])
 }
@@ -85,6 +86,7 @@ model Quiz {
   questionIds String[]
   dateCreated DateTime    @default(now())
   likeCounter LikeCounter
+  private Boolean
 
   @@index([creatorId])
 }

--- a/studyAi/src/app/api/graphql/apolloClient.ts
+++ b/studyAi/src/app/api/graphql/apolloClient.ts
@@ -1,5 +1,6 @@
 import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
 import { ApolloClient, InMemoryCache } from "@apollo/client";
+import { NextRequest } from "next/server";
 const env = process.env.NODE_ENV;
 export const createGraphQLClient = (url: string) =>
   new ApolloClient({
@@ -22,4 +23,8 @@ if (env === "development") {
   loadErrorMessages();
 }
 const ServerGraphQLClient = createGraphQLClient(generateURL());
+const ServerGraphQLClientProvider = (req: NextRequest) => {
+  //req.cookies.set()
+  return ServerGraphQLClient;
+}
 export default ServerGraphQLClient;

--- a/studyAi/src/app/api/graphql/apolloClientClient.ts
+++ b/studyAi/src/app/api/graphql/apolloClientClient.ts
@@ -1,6 +1,8 @@
 import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
-import { ApolloClient, InMemoryCache } from "@apollo/client";
-import { NextRequest } from "next/server";
+import {
+  ApolloClient,
+  InMemoryCache,
+} from "@apollo/client";
 const env = process.env.NODE_ENV;
 export const createGraphQLClient = (url: string) =>
   new ApolloClient({
@@ -22,9 +24,3 @@ if (env === "development") {
   loadDevMessages();
   loadErrorMessages();
 }
-const ServerGraphQLClient = createGraphQLClient(generateURL());
-const ServerGraphQLClientProvider = (req: NextRequest) => {
-  //req.cookies.set()
-  return ServerGraphQLClient;
-}
-export default ServerGraphQLClient;

--- a/studyAi/src/app/api/graphql/apolloServerClient.ts
+++ b/studyAi/src/app/api/graphql/apolloServerClient.ts
@@ -1,0 +1,61 @@
+import {
+  ApolloClient,
+  InMemoryCache,
+  NormalizedCacheObject,
+  createHttpLink,
+} from "@apollo/client";
+import { IncomingHttpHeaders } from "http";
+import { Session } from "next-auth";
+import { cookies } from "next/headers";
+import { createGraphQLClient, generateURL } from "./apolloClientClient";
+const createServerGraphQLClient = (
+  cookie: IncomingHttpHeaders["cookie"],
+  url: string
+) => {
+  if (!cookie) return createGraphQLClient(generateURL());
+  return new ApolloClient({
+    ssrMode: true,
+    link: createHttpLink({
+      uri: url,
+      credentials: "same-origin",
+      headers: {
+        cookie: cookie,
+      },
+    }),
+    cache: new InMemoryCache(),
+  });
+};
+
+class ServerGraphQLClientClass {
+  client: ApolloClient<NormalizedCacheObject> | null;
+  hasCookieSet?: boolean;
+  constructor(cookie?: IncomingHttpHeaders["cookie"]) {
+    this.client = cookie
+      ? createServerGraphQLClient(cookie, generateURL())
+      : null;
+    this.hasCookieSet = !!cookie;
+  }
+  //determines if the cookie has been set.
+  //If it has, no new client.
+  //if it hasnt we will need
+  setClient(session: Session | null, cookie: IncomingHttpHeaders["cookie"]) {
+    if (this.client && this.hasCookieSet) return this.client;
+    //get cookie
+    if ((this.hasCookieSet = !!cookie && !!session))
+      this.client = createServerGraphQLClient(cookie, generateURL());
+    else this.client = createGraphQLClient(generateURL());
+    //ensure session is valid if not, we need a new client
+    return this.client;
+  }
+}
+const ServerGraphQLClientInstance = new ServerGraphQLClientClass();
+const ServerGraphQLClient = (session: Session | null) => {
+  const allCookies = cookies();
+  const mergedCookie = allCookies
+    .getAll()
+    .map((cookie) => cookie.name + "=" + cookie.value)
+    .reduce((a, b) => `${a}; ${b}`);
+  const client = ServerGraphQLClientInstance.setClient(session, mergedCookie);
+  return client;
+};
+export default ServerGraphQLClient;

--- a/studyAi/src/app/api/graphql/graphql.ts
+++ b/studyAi/src/app/api/graphql/graphql.ts
@@ -23,6 +23,7 @@ const canUserModify = (userId: string | undefined, creatorId: string) => {
 const main = startServerAndCreateNextHandler(server, {
   context: async (req: any, res: any) => {
     let session: Session | null = null;
+    const body = await req.graphQLbody
     try {
       res.getHeader = (name: string) => res.headers?.get(name);
       res.setHeader = (name: string, value: string) =>
@@ -49,7 +50,6 @@ const main = startServerAndCreateNextHandler(server, {
     // // if a user has access. If the route doesnt require access, do
     // // not call this function
     // canUserModify(session?.user?.id, actualId);
-
     const contextData = {
       req,
       res: res as NextApiResponse,

--- a/studyAi/src/app/api/graphql/graphql.ts
+++ b/studyAi/src/app/api/graphql/graphql.ts
@@ -31,24 +31,24 @@ const main = startServerAndCreateNextHandler(server, {
     } catch (e) {
       session = null;
     }
-    let actualId = req.body.variables.creatorId
-      ? req.body.variables.creatorId
-      : req.body.variables.userId
-      ? req.body.variables.userId
-      : req.body.variables.id;
-    let resolverRequested = req.body.query.split("{")[1].split("(")[0];
-    // Cases to consider: queries where user doesn't need to be logged in (getAll type), question and quiz contains creatorId`
-    // All mutations (add, update, delete) will have creatorId
+    // let actualId = req.body.variables.creatorId
+    //   ? req.body.variables.creatorId
+    //   : req.body.variables.userId
+    //   ? req.body.variables.userId
+    //   : req.body.variables.id;
+    // let resolverRequested = req.body.query.split("{")[1].split("(")[0];
+    // // Cases to consider: queries where user doesn't need to be logged in (getAll type), question and quiz contains creatorId`
+    // // All mutations (add, update, delete) will have creatorId
 
-    console.log("-----------------------------------");
-    console.log(req.body);
-    console.log("-----------------------------------");
+    // console.log("-----------------------------------");
+    // console.log(req.body);
+    // console.log("-----------------------------------");
 
-    // Session may be null (eg. question library page)
-    // use the following function when you want to explicity check
-    // if a user has access. If the route doesnt require access, do
-    // not call this function
-    canUserModify(session?.user?.id, actualId);
+    // // Session may be null (eg. question library page)
+    // // use the following function when you want to explicity check
+    // // if a user has access. If the route doesnt require access, do
+    // // not call this function
+    // canUserModify(session?.user?.id, actualId);
 
     const contextData = {
       req,

--- a/studyAi/src/app/api/graphql/lib/startServerAndCreateNextHandler.ts
+++ b/studyAi/src/app/api/graphql/lib/startServerAndCreateNextHandler.ts
@@ -26,10 +26,10 @@ function startServerAndCreateNextHandler<
   async function handler<HandlerReq extends NextRequest | Request>(req: HandlerReq, res?: undefined): Promise<Response>;
   async function handler(req: HandlerRequest, res: NextApiResponse | undefined) {
     const bodyAccessed = await getBody(req)
-    const newReq = {...req, body: bodyAccessed}
+    const newReq = {...req, graphQLBody: bodyAccessed}
 
     const httpGraphQLResponse = await server.executeHTTPGraphQLRequest({
-      context: () => contextFunction(newReq as Req, res as Req extends NextApiRequest ? NextApiResponse : undefined),
+      context: () => contextFunction(newReq as unknown as Req, res as Req extends NextApiRequest ? NextApiResponse : undefined),
       httpGraphQLRequest: {
         body: bodyAccessed,
         headers: getHeaders(req),

--- a/studyAi/src/app/dashboard/page.tsx
+++ b/studyAi/src/app/dashboard/page.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { protectRouteSSR } from "../api/utils/sessionFuncs";
 import NavigationWrapper from "../util/components/navigation/navigationWrapper";
-import ServerGraphQLClient from "../api/graphql/apolloClient";
-import { Question } from "../../../prisma/generated/type-graphql";
-import GreetingBanner from "./server/greetingBannerContainer";
+import GreetingBannerContainer from "./server/greetingBannerContainer";
 import Profile from "./server/profile";
-import { gql } from 'graphql-tag';
-import Blah from "./blah"
+import Blah from "./blah";
 
 export default async function DashboardPage() {
   const sessionData = await protectRouteSSR("/auth/login");
@@ -19,9 +16,9 @@ export default async function DashboardPage() {
       }}
       usePadding
     >
-      <Blah />
-      <Profile />
-      <GreetingBanner />
+      {/* <Blah />
+      <Profile /> */}
+      <GreetingBannerContainer />
       {/* <QuestionEditor /> */}
     </NavigationWrapper>
   );

--- a/studyAi/src/app/dashboard/server/greetingBannerContainer.tsx
+++ b/studyAi/src/app/dashboard/server/greetingBannerContainer.tsx
@@ -2,10 +2,11 @@ import { options } from "@/app/api/auth/[...nextauth]/options";
 import { getServerSession } from "next-auth";
 import GreetingBanner from "./greetingBanner";
 import { sub } from "date-fns";
-import ServerGraphQLClient from "@/app/api/graphql/apolloClient";
+import ServerGraphQLClient from "@/app/api/graphql/apolloServerClient";
 import { Question } from "../../../../prisma/generated/type-graphql";
 import { QuestionSubmission } from "@prisma/client";
 import { gql } from "../../../../graphql/generated";
+
 const QueryUserGeneratedQuestions = gql(`
   query QueryUserGeneratedQuestions(
     $id: String
@@ -42,6 +43,7 @@ const QueryQuestionSubmissions = gql(`
 `);
 const GreetingBannerContainer = async () => {
   const session = await getServerSession(options);
+  const client = ServerGraphQLClient(session);
   const userId = session?.user.id;
   const userName = session?.user.name;
   if (!userName || !userId) return <></>;
@@ -66,8 +68,8 @@ const GreetingBannerContainer = async () => {
       ...queryVariables,
     },
   };
-  const questionPromise = ServerGraphQLClient.query(questionQuery);
-  const submissionsPromise = ServerGraphQLClient.query(submissionsQuery);
+  const questionPromise = client.query(questionQuery);
+  const submissionsPromise = client.query(submissionsQuery);
   try {
     const [questionsResult, submissionsResult] = await Promise.all([
       questionPromise,

--- a/studyAi/src/app/library/question/[id]/page.tsx
+++ b/studyAi/src/app/library/question/[id]/page.tsx
@@ -68,6 +68,7 @@ export default async function QuestionPage({
   try {
     const { data: result } = await ServerGraphQLClient.query(query);
     const data = result.question as (Partial<Question> & { id: string }) | null;
+    console.log(data)
     // const data = question;
     return (
       <NavigationWrapper

--- a/studyAi/src/app/library/question/[id]/page.tsx
+++ b/studyAi/src/app/library/question/[id]/page.tsx
@@ -1,10 +1,12 @@
 import NavigationWrapper from "@/app/util/components/navigation/navigationWrapper";
-import ServerGraphQLClient from "@/app/api/graphql/apolloClient";
+import ServerGraphQLClient from "@/app/api/graphql/apolloServerClient";
 import QuestionPageContainer from "../components/client/questionPageContainer";
 import { Question } from "../../../../../prisma/generated/type-graphql";
 import { QuestionsContainer } from "@/app/stores/questionStore";
 import { QuestionTypes } from "@/app/util/types/UserData";
 import { gql } from "../../../../../graphql/generated";
+import { getServerSession } from "next-auth";
+import { options } from "@/app/api/auth/[...nextauth]/options";
 const question: Partial<Question> & {
   id: string;
   questionType: (typeof QuestionTypes)[number];
@@ -66,9 +68,11 @@ export default async function QuestionPage({
     variables: { id: questionId },
   };
   try {
-    const { data: result } = await ServerGraphQLClient.query(query);
+    const session = await getServerSession(options)
+    const client = ServerGraphQLClient(session);
+    const { data: result } = await client.query(query);
     const data = result.question as (Partial<Question> & { id: string }) | null;
-    console.log(data)
+    // console.log(data)
     // const data = question;
     return (
       <NavigationWrapper

--- a/studyAi/src/app/util/providers/apolloProvider.tsx
+++ b/studyAi/src/app/util/providers/apolloProvider.tsx
@@ -1,6 +1,9 @@
 "use client";
 import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
-import { createGraphQLClient, generateURL } from "../../api/graphql/apolloClient";
+import {
+  createGraphQLClient,
+  generateURL,
+} from "../../api/graphql/apolloClientClient";
 import { ApolloProvider } from "@apollo/client";
 const env = process.env.NODE_ENV;
 export const ClientSideApolloClient = createGraphQLClient(generateURL());


### PR DESCRIPTION
Fixed session becoming null when querying graphql api on server component, by creating a class that stores the apollo client on the server, and auto-sets the cookie properly when a query is made