### PR TITLE
Fixed session returning null do to a shallow copy of request object

### DIFF
--- a/studyAi/src/app/api/graphql/lib/startServerAndCreateNextHandler.ts
+++ b/studyAi/src/app/api/graphql/lib/startServerAndCreateNextHandler.ts
@@ -26,7 +26,9 @@ function startServerAndCreateNextHandler<
   async function handler<HandlerReq extends NextRequest | Request>(req: HandlerReq, res?: undefined): Promise<Response>;
   async function handler(req: HandlerRequest, res: NextApiResponse | undefined) {
     const bodyAccessed = await getBody(req)
-    const newReq = {...req, graphQLBody: bodyAccessed}
+    //we add this value to request object
+    const newReq = req as any;
+    newReq.graphQLBody = bodyAccessed;
     const httpGraphQLResponse = await server.executeHTTPGraphQLRequest({
       context: () => contextFunction(newReq as unknown as Req, res as Req extends NextApiRequest ? NextApiResponse : undefined),
       httpGraphQLRequest: {

--- a/studyAi/src/app/api/graphql/validateAuthRequirementInQuery.ts
+++ b/studyAi/src/app/api/graphql/validateAuthRequirementInQuery.ts
@@ -1,4 +1,3 @@
-import "reflect-metadata";
 import { getServerSession } from "next-auth";
 import { options } from "../auth/[...nextauth]/options";
 import { Session } from "next-auth";
@@ -8,7 +7,8 @@ export const getSession = async (req: any, res: any) => {
     res.getHeader = (name: string) => res.headers?.get(name);
     res.setHeader = (name: string, value: string) =>
       res.headers?.set(name, value);
-    return await getServerSession(req, res, options);
+    const session = await getServerSession(req, res, options)
+    return session;
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
session was returning null do to a shallow copy of request object. Instead we need to modify the request object directly and pass it on, to keep cookie data, because cookie data is considered a private key in the object